### PR TITLE
User Configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ target/
 
 .env
 
-testaudiolib
+rpconfig.toml
 
 
 # sqlite stuff

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,6 +577,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99de365f605554ae33f115102a02057d4fc18b01f3284d6870be0938743cfe7d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1358,7 @@ dependencies = [
  "chrono",
  "claxon",
  "cpal",
+ "directories-next",
  "futures",
  "hound",
  "log 0.4.11",
@@ -2069,6 +2091,16 @@ name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+
+[[package]]
+name = "redox_users"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+dependencies = [
+ "getrandom 0.1.15",
+ "redox_syscall",
+]
 
 [[package]]
 name = "regex"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,12 +23,19 @@ checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
 
 [[package]]
 name = "ahash"
-version = "0.5.10"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19fac972e53443ba111b1ff866e9d3b6484df5c05030e13bc7c6a1ebc802e983"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+
+[[package]]
+name = "ahash"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75b7e6a93ecd6dbd2c225154d0fa7f86205574ecaa6c87429fb5f66ee677c44"
 dependencies = [
  "getrandom 0.2.0",
  "lazy_static",
+ "version_check",
 ]
 
 [[package]]
@@ -134,9 +141,9 @@ dependencies = [
 
 [[package]]
 name = "atoi"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c897df197d57c25b37df9d8fa2f93ddbfeee9ebd2264350ac79c8ec4b795885"
+checksum = "616896e05fc0e2649463a93a15183c6a16bf03413a7af88ef1285ddedfa9cda5"
 dependencies = [
  "num-traits 0.2.14",
 ]
@@ -212,11 +219,32 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -230,6 +258,12 @@ name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -273,6 +307,18 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f95cf4bf0dda0ac2e65371ae7215d0dce3c187613a9dbf23aaa9374186f97a"
+dependencies = [
+ "semver 0.11.0",
+ "semver-parser 0.10.0",
+ "serde 1.0.118",
+ "serde_json 1.0.60",
 ]
 
 [[package]]
@@ -491,33 +537,32 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
+ "cfg-if 1.0.0",
  "crossbeam-utils",
- "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.2.3"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "774ba60a54c213d409d5353bda12d49cd68d14e45036a285234c8d6f91f92570"
+checksum = "0f6cb3c7f5b8e51bc3ebb73a2327ad4abdbd119dc13223f14f961d2f38486756"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
- "maybe-uninit",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -569,11 +614,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.3",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -694,6 +748,12 @@ dependencies = [
  "backtrace",
  "version_check",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "fetch_unroll"
@@ -955,6 +1015,15 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "generic-array"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
@@ -1131,6 +1200,24 @@ dependencies = [
  "libc",
  "pango-sys",
  "system-deps",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.7",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d99cf782f0dc4372d26846bec3de7804ceb5df083c2d4462c0b8d2330e894fa8"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -1364,8 +1451,11 @@ dependencies = [
  "log 0.4.11",
  "minimp3",
  "rtag",
+ "serde 1.0.118",
+ "serde_derive 1.0.118",
  "sqlx",
  "tokio 1.0.1",
+ "toml",
 ]
 
 [[package]]
@@ -1459,15 +1549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lru-cache"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
-dependencies = [
- "linked-hash-map",
-]
-
-[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,12 +1568,6 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
-
-[[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -1788,6 +1863,12 @@ checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -1897,6 +1978,49 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99b8db626e31e5b81787b9783425769681b347011cc59471e33ea46d2ea0cf55"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote 1.0.7",
+ "syn 1.0.54",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54be6e404f5317079812fc8f9f5279de376d8856929e21c184ecf6bbd692a11d"
+dependencies = [
+ "maplit",
+ "pest",
+ "sha-1",
+]
 
 [[package]]
 name = "pin-project"
@@ -2205,7 +2329,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
- "semver",
+ "semver 0.9.0",
 ]
 
 [[package]]
@@ -2297,7 +2421,17 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser",
+ "semver-parser 0.7.0",
+]
+
+[[package]]
+name = "semver"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
+dependencies = [
+ "semver-parser 0.10.0",
+ "serde 1.0.118",
 ]
 
 [[package]]
@@ -2305,6 +2439,16 @@ name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+
+[[package]]
+name = "semver-parser"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e012c6c5380fb91897ba7b9261a0f565e624e869d42fe1a1d03fa0d68a083d5"
+dependencies = [
+ "pest",
+ "pest_derive",
+]
 
 [[package]]
 name = "serde"
@@ -2398,6 +2542,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2409,11 +2565,11 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpuid-bool",
- "digest",
- "opaque-debug",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -2466,9 +2622,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1f8eb788e1733bdbf69a8f97087213ebdebd253d4782c686d3cfd586b0a9453"
+checksum = "e1a98f9bf17b690f026b6fec565293a995b46dfbd6293debcb654dcffd2d1b34"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2476,11 +2632,11 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e647268dc1239dd9db2d3103fefd61151971a2214882cff9efea6f60cf50840"
+checksum = "36bb6a2ca3345a86493bc3b71eabc2c6c16a8bb1aa476cf5303bee27f67627d7"
 dependencies = [
- "ahash",
+ "ahash 0.6.2",
  "atoi",
  "bitflags",
  "byteorder",
@@ -2494,12 +2650,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "hashlink",
  "hex",
  "itoa 0.4.6",
  "libc",
  "libsqlite3-sys",
  "log 0.4.11",
- "lru-cache",
  "memchr",
  "once_cell",
  "parking_lot",
@@ -2516,14 +2672,16 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7acd32cba35531345f8a94a038874baf00efd0b701c913f5b00d2870b474b64"
+checksum = "2b5ada8b3b565331275ce913368565a273a74faf2a34da58c4dc010ce3286844"
 dependencies = [
+ "cargo_metadata",
  "dotenv",
  "either",
  "futures",
  "heck",
+ "lazy_static",
  "proc-macro2",
  "quote 1.0.7",
  "sha2",
@@ -2930,9 +3088,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cf45bb0bef80604d001caaec0d09da99611b3c0fd39d3080468875cdb65645"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
  "serde 1.0.118",
 ]
@@ -2957,6 +3115,12 @@ name = "typenum"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "ucd-util"
@@ -3213,9 +3377,13 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "0.9.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7884773ab69074615cb8f8425d0e53f11710786158704fca70f53e71b0e05504"
+checksum = "d595b2e146f36183d6a590b8d41568e2bc84c922267f43baf61c956330eeb436"
+dependencies = [
+ "wasm-bindgen",
+ "web-sys",
+]
 
 [[package]]
 name = "winapi"

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,6 +1,12 @@
 - error handling
   - crates: thiserror, anyhow?
 - ensure simd for track parsing?
+- FIX GTK+ MEMORY LEAK
+  - only happens once an audio stream is started, data is fine till then
+  - LINUX: once audio is played, memory starts to steadily climb up. pausing/playing
+  doesn't seem to make a difference, if anything playing more may cause more problems
+  - NB - MAC: looks like the memory shoots up once the track is paused, and drops back down after being played. 
+  - TODO verify if this is a linux only problem?
 
 
 ## linux -> windows x86_64-pc-windows-gnu cross compilation
@@ -10,3 +16,11 @@ deps
 - mingw64-gcc
 - mingw64-openssl
 - mingw64-gtk3
+
+# configuration implementation
+
+- `open_or_create` - librarian looks for an existing database in the local data directory (e.g. `$HOME/Library/Application Support` on mac, `$HOME/.local/share` on linux)
+  - if it doesn't exist, create it along with all other intermediary folders needed
+  - migrations should be located in same data dir as db
+- user configuration is stored in the db. if this is a fresh DB, it should
+use system based defaults

--- a/librarian/Cargo.toml
+++ b/librarian/Cargo.toml
@@ -9,7 +9,7 @@ name = 'librarian'
 
 [dependencies]
 tokio = {version = "1.0.1", features = ["fs", "sync"]}
-sqlx = {version = "0.4.1", default-features = false, features = ["runtime-tokio-native-tls", "sqlite", "chrono", "macros", "migrate"]}
+sqlx = {version = "0.4.2", default-features = false, features = ["runtime-tokio-native-tls", "sqlite", "chrono", "macros", "migrate"]}
 claxon = "0.4.3"
 futures = "0.3.8"
 chrono = "0.4"
@@ -22,5 +22,8 @@ aiff = {git = "https://github.com/julientregoat/aiff-rs.git"}
 cpal = {git = "https://github.com/julientregoat/cpal.git", branch = "32bit"}
 # num-traits = "0.2.14"
 directories-next = "2.0.0"
+toml = "0.5.8"
+serde = "1.0.118"
+serde_derive = "1.0.118"
 
 [dev-dependencies]

--- a/librarian/Cargo.toml
+++ b/librarian/Cargo.toml
@@ -21,6 +21,6 @@ aiff = {git = "https://github.com/julientregoat/aiff-rs.git"}
 # cpal = {path = "../../cpal"}
 cpal = {git = "https://github.com/julientregoat/cpal.git", branch = "32bit"}
 # num-traits = "0.2.14"
-# directories-next = "2.0.0"
+directories-next = "2.0.0"
 
 [dev-dependencies]

--- a/librarian/src/models.rs
+++ b/librarian/src/models.rs
@@ -252,6 +252,7 @@ impl Track {
             .await
     }
 
+    // TODO should this be outside the Track impl?
     pub async fn get_all_detailed(
         conn: &mut SqlitePoolConn,
     ) -> Result<Vec<DetailedTrack>, sqlx::Error> {

--- a/ui-gtk/src/events.rs
+++ b/ui-gtk/src/events.rs
@@ -68,15 +68,8 @@ pub async fn librarian_event_loop(
     while let Some(msg) = listener.recv().await {
         match msg {
             LibraryMsg::RefreshTracklist => {
-                let mut conn = lib.db_pool.acquire().compat().await.unwrap();
-                let result =
-                    librarian::models::Track::get_all_detailed(&mut conn)
-                        .compat()
-                        .await
-                        .unwrap();
-                {
-                    app_chan.send(AppMsg::Tracklist(result)).unwrap();
-                }
+                let result = lib.get_tracklist().compat().await;
+                app_chan.send(AppMsg::Tracklist(result)).unwrap();
             }
             LibraryMsg::ImportDir(path) => {
                 // ideally, this should return tracks in a stream so the UI

--- a/ui-gtk/src/events.rs
+++ b/ui-gtk/src/events.rs
@@ -74,18 +74,7 @@ pub async fn librarian_event_loop(
             LibraryMsg::ImportDir(path) => {
                 // ideally, this should return tracks in a stream so the UI
                 // is updated with information faster
-                let imported_tracks = lib
-                    .import_dir(
-                        // FIXME get lib path properly; librarian to handle
-                        PathBuf::from(
-                            std::env::var("LIB_DIR")
-                                .unwrap_or(String::from("../../recordplayer")),
-                        )
-                        .as_path(),
-                        path,
-                    )
-                    .compat()
-                    .await;
+                let imported_tracks = lib.import_dir(path).compat().await;
                 {
                     app_chan
                         .send(AppMsg::ImportedTracks(imported_tracks))

--- a/ui-gtk/src/main.rs
+++ b/ui-gtk/src/main.rs
@@ -169,7 +169,7 @@ pub async fn main() {
 
     let lib = librarian::Library::open_or_create(db_dir).compat().await;
     tokio::spawn(async move {
-        events::librarian_event_loop(lib, rx_lib, tx_app.clone()).await
+        events::librarian_event_loop(lib, rx_lib, tx_app).await
     });
 
     let application = gtk::ApplicationBuilder::new()

--- a/ui-gtk/src/main.rs
+++ b/ui-gtk/src/main.rs
@@ -167,7 +167,7 @@ pub async fn main() {
 
     rx_app.attach(Some(&main_ctx), events::app_event_loop(app_state.clone()));
 
-    let lib = librarian::Library::open_or_create(db_dir).compat().await;
+    let lib = librarian::Library::open_or_create().compat().await;
     tokio::spawn(async move {
         events::librarian_event_loop(lib, rx_lib, tx_app).await
     });


### PR DESCRIPTION
- enables user configuration through a `rpconfig.toml` file 
- enforces `copy_on_import` and `library_dir` configs
- defaults config + import dirs to standard OS dirs
  -`RP_CONFIG_DIR` env var is now exposed to let devs override the default system config folder. this folder should contain the db migrations, and a db + config file will be created here if not already present.


also some minor cleanup and left notes on gtk memory leak